### PR TITLE
Remove direct admin users from opensafely repos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,8 @@ privileged secret, so it currently runs from Simon's home machine.
 Run set up a cronjob yourself, you can use `cronjob.sh`. First, edit the `tokenfile` variable to
 point a file with a GH PAT that has admin org permissions.
 
-Then, set it to run every 15 mins or so via `crontab -e` or similar
+Then, set it to run every hour at n minutes past the hour via `crontab -e` or similar.
+e.g. to run at 17m past each hour:
 
-`*/15 * * * * /path/to/cronjob.sh >> /path/to/logfile.log 2>&1`
-
-
-
+`17 * * * * /path/to/cronjob.sh >> /path/to/logfile.log 2>&1`
 

--- a/manage-github.py
+++ b/manage-github.py
@@ -137,8 +137,19 @@ def protect_branch(repo, branch=None, **kwargs):
 
 def configure_repo(repo, **kwargs):
     """Configure a repo according to config."""
+
+    for user in repo.get_collaborators("direct"):
+        # a direct user with the admin permission is the repo creator, or someone added by the repo creator
+        if user.permissions.admin:
+            yield client.Change(
+                lambda: repo.remove_from_collaborators(user),
+                f"removing direct admin collaborator {user.login} from {repo.name}",
+            )
+
+    # if it's archived we can't change policy
     if repo.archived:
         return
+
     to_change = {}
     for name, value  in kwargs.items():
         if getattr(repo, name) != value:

--- a/manage-github.py
+++ b/manage-github.py
@@ -138,13 +138,19 @@ def protect_branch(repo, branch=None, **kwargs):
 def configure_repo(repo, **kwargs):
     """Configure a repo according to config."""
 
-    for user in repo.get_collaborators("direct"):
-        # a direct user with the admin permission is the repo creator, or someone added by the repo creator
-        if user.permissions.admin:
-            yield client.Change(
-                lambda: repo.remove_from_collaborators(user),
-                f"removing direct admin collaborator {user.login} from {repo.name}",
-            )
+    try:
+        for user in repo.get_collaborators("direct"):
+            # a direct user with the admin permission is the repo creator, or someone added by the repo creator
+            if user.permissions.admin:
+                yield client.Change(
+                    lambda: repo.remove_from_collaborators(user),
+                    f"removing direct admin collaborator {user.login} from {repo.name}",
+                )
+    except GithubException as exc:
+        if exc.status == 403:
+            print("Token does not have permissions to query repo collabortors (need write access)")
+        else:
+            raise
 
     # if it's archived we can't change policy
     if repo.archived:


### PR DESCRIPTION
We want all access to be controlled by teams, not who created the repo.
This allows us to re-organise, handle leavers, etc, much better too.
