### PR TITLE
fix: expose a docker port for the otel-gateway test

### DIFF
--- a/services/otel-gateway/justfile
+++ b/services/otel-gateway/justfile
@@ -40,15 +40,14 @@ test-ci: venv
 
     # run a different instance of a collector as a test endpoint
     docker rm --force otel-gateway-test 2>/dev/null || true
-    docker run -d --name otel-gateway-test -u "$(id -u):$(id -g)" \
+    docker run -d -p 4318:4318 --name otel-gateway-test -u "$(id -u):$(id -g)" \
         -v $PWD/test-config.yaml:/etc/otelcol-contrib/config.yaml \
         -v $PWD/exported:/exported \
         otel/opentelemetry-collector-contrib:0.62.1
 
     test "$(docker inspect otel-gateway-test -f '{{{{.State.Status}}')" == "running" || { docker logs otel-gateway-test; exit 1; }
 
-    TEST_IP="$(docker inspect -f '{{{{range.NetworkSettings.Networks}}{{{{.IPAddress}}{{{{end}}' otel-gateway-test)"
-    export ENDPOINT="http://$TEST_IP:4318"
+    export ENDPOINT="http://127.0.0.1:4318"
 
     # run otel-gateway pointing at the test endpoint
     {{ just_executable() }} run -d -e ENDPOINT -e LOG_LEVEL=debug
@@ -61,10 +60,10 @@ test-ci: venv
 run-python *args: venv
     #!/bin/bash
     set -eu
-    GATEWAY_IP="$(docker inspect -f '{{{{range.NetworkSettings.Networks}}{{{{.IPAddress}}{{{{end}}' otel-gateway)"
     TOKEN=$(echo -n "$BASIC_AUTH_USER:$BASIC_AUTH_PASSWORD" | base64)
 
-    export OTEL_EXPORTER_OTLP_ENDPOINT="http://$GATEWAY_IP:4318"
+
+    export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4318"
     export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic%20$TOKEN"
     export OTEL_SERVICE_NAME="otel-gateway-tests"
  

--- a/services/otel-gateway/justfile
+++ b/services/otel-gateway/justfile
@@ -55,6 +55,8 @@ test-ci: venv
     test "$(docker inspect otel-gateway -f '{{{{.State.Status}}')" == "running" || { docker logs otel-gateway; exit 1; }
     {{ just_executable() }} run-python -m pytest tests.py
 
+    docker stop otel-gateway
+    docker stop otel-gateway-test
 
 # run a python script in the correct environment 
 run-python *args: venv


### PR DESCRIPTION
* this implementation works on MacOS (the previous only worked on Linux)