### PR TITLE
fix: test-ci was bypassing the otel-gateway container

### DIFF
--- a/services/otel-gateway/justfile
+++ b/services/otel-gateway/justfile
@@ -41,13 +41,13 @@ test-ci: venv
     mkdir -p exported
 
     # run a different instance of a collector as a test endpoint
-    docker rm --force otel-gateway-test 2>/dev/null || true
-    docker run -d -p 4319:4318 --name otel-gateway-test -u "$(id -u):$(id -g)" \
+    docker rm --force mock-honeycomb 2>/dev/null || true
+    docker run -d -p 4319:4318 --name mock-honeycomb -u "$(id -u):$(id -g)" \
         -v $PWD/test-config.yaml:/etc/otelcol-contrib/config.yaml \
         -v $PWD/exported:/exported \
         otel/opentelemetry-collector-contrib:0.62.1
 
-    test "$(docker inspect otel-gateway-test -f '{{{{.State.Status}}')" == "running" || { docker logs otel-gateway-test; exit 1; }
+    test "$(docker inspect mock-honeycomb -f '{{{{.State.Status}}')" == "running" || { docker logs mock-honeycomb; exit 1; }
 
     export ENDPOINT="http://host.docker.internal:4319"
 
@@ -58,7 +58,7 @@ test-ci: venv
     {{ just_executable() }} run-python -m pytest tests.py
 
     docker stop otel-gateway
-    docker stop otel-gateway-test
+    docker stop mock-honeycomb
 
 # run a python script in the correct environment 
 run-python *args: venv

--- a/services/otel-gateway/justfile
+++ b/services/otel-gateway/justfile
@@ -27,7 +27,7 @@ test-integration: venv
     #!/bin/bash
     set -euo pipefail
 
-    {{ just_executable() }} run -d -e LOG_LEVEL=debug
+    {{ just_executable() }} run -d -e LOG_LEVEL=debug -p 4318:4318
     {{ just_executable() }} run-python tests.py
     echo "Data sent to honeycomb"
     echo "https://ui.honeycomb.io/bennett-institute-for-applied-data-science/environments/development/datasets/otel-gateway-tests?query=%7B%22time_range%22%3A600%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%5D%2C%22calculations%22%3A%5B%5D%2C%22orders%22%3A%5B%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A100%7D"

--- a/services/otel-gateway/justfile
+++ b/services/otel-gateway/justfile
@@ -42,17 +42,17 @@ test-ci: venv
 
     # run a different instance of a collector as a test endpoint
     docker rm --force otel-gateway-test 2>/dev/null || true
-    docker run -d -p 4318:4318 --name otel-gateway-test -u "$(id -u):$(id -g)" \
+    docker run -d -p 4319:4318 --name otel-gateway-test -u "$(id -u):$(id -g)" \
         -v $PWD/test-config.yaml:/etc/otelcol-contrib/config.yaml \
         -v $PWD/exported:/exported \
         otel/opentelemetry-collector-contrib:0.62.1
 
     test "$(docker inspect otel-gateway-test -f '{{{{.State.Status}}')" == "running" || { docker logs otel-gateway-test; exit 1; }
 
-    export ENDPOINT="http://127.0.0.1:4318"
+    export ENDPOINT="http://host.docker.internal:4319"
 
     # run otel-gateway pointing at the test endpoint
-    {{ just_executable() }} run -d -e ENDPOINT -e LOG_LEVEL=debug
+    {{ just_executable() }} run -d -e ENDPOINT -e LOG_LEVEL=debug -p 4318:4318 --add-host=host.docker.internal:host-gateway
 
     test "$(docker inspect otel-gateway -f '{{{{.State.Status}}')" == "running" || { docker logs otel-gateway; exit 1; }
     {{ just_executable() }} run-python -m pytest tests.py

--- a/services/otel-gateway/tests.py
+++ b/services/otel-gateway/tests.py
@@ -4,10 +4,8 @@ import time
 from pathlib import Path
 
 from opentelemetry import metrics, trace
-from opentelemetry.exporter.otlp.proto.http.metric_exporter import \
-    OTLPMetricExporter
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import \
-    OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.metrics import (
     get_meter_provider,
     set_meter_provider,
@@ -30,7 +28,7 @@ tracer = trace.get_tracer("testscope")
 
 # set up metric exporting
 exporter = OTLPMetricExporter()
-# There isn't a direct equivalent of SimpleSpanProcessor, but with the 
+# There isn't a direct equivalent of SimpleSpanProcessor, but with the
 # export interval set to 1sec it's close enough
 reader = PeriodicExportingMetricReader(exporter, export_interval_millis=1000)
 meter_provider = MeterProvider(metric_readers=[reader])
@@ -54,8 +52,12 @@ def generate_test_metric():
 
 def get_output(path):
     # wait for file to be written to, typically a few hundred 100ms
+    timeout_count = 0
     while path.exists() and path.stat().st_size == 0:
         time.sleep(0.01)
+        timeout_count = timeout_count + 1
+        if timeout_count > 500:
+            raise Exception("Test timed out - no output written to file after 5 seconds")
 
     return json.loads(path.read_text())
 
@@ -63,11 +65,11 @@ def get_output(path):
 def service_name_helper(resource_attributes):
     # annoying json
     return list(
-            filter(
-                lambda d: d["key"] == "service.name",
-                resource_attributes,
-            )
-        )[0]
+        filter(
+            lambda d: d["key"] == "service.name",
+            resource_attributes,
+        )
+    )[0]
 
 
 def test_trace():
@@ -104,7 +106,7 @@ def test_metric():
     assert metric["scopeMetrics"][0]["scope"]["name"] == "testmetricscope"
     metric_data = metric["scopeMetrics"][0]["metrics"][0]
     assert metric_data["name"] == "counter"
-    assert metric_data["sum"]["dataPoints"][0]["asInt"] == '3'
+    assert metric_data["sum"]["dataPoints"][0]["asInt"] == "3"
 
 
 if __name__ == "__main__":
@@ -112,7 +114,3 @@ if __name__ == "__main__":
     generate_test_trace()
     print("Generating metric data")
     generate_test_metric()
-
-
-
-


### PR DESCRIPTION
* https://github.com/opensafely-core/sysadmin/pull/91 actually just bypassed the otel-gateway container & sent telemetry direct to otel-gateway-test
* needs `--add-host=host.docker.internal:host-gateway` for linux
* see also https://stackoverflow.com/questions/31324981/how-to-access-host-port-from-docker-container
* blacken test python