### PR TITLE
chore(deps): bump otel/opentelemetry-collector-contrib

### DIFF
--- a/services/otel-gateway/Dockerfile
+++ b/services/otel-gateway/Dockerfile
@@ -4,7 +4,7 @@
 # 
 # https://github.com/open-telemetry/opentelemetry-collector-releases/blob/main/distributions/otelcol/Dockerfile
 #
-FROM otel/opentelemetry-collector-contrib:0.84.0
+FROM otel/opentelemetry-collector-contrib:0.86.0
 
 LABEL org.opencontainers.image.authors="tech@opensafely.org" \
       org.opencontainers.image.url="opensafely.org" \


### PR DESCRIPTION
Bumps otel/opentelemetry-collector-contrib from 0.84.0 to 0.86.0.

---
updated-dependencies:
- dependency-name: otel/opentelemetry-collector-contrib dependency-type: direct:production update-type: version-update:semver-minor ...