### PR TITLE
update otel collector to v102

### DIFF
--- a/services/otel-gateway/Dockerfile
+++ b/services/otel-gateway/Dockerfile
@@ -4,7 +4,7 @@
 # 
 # https://github.com/open-telemetry/opentelemetry-collector-releases/blob/main/distributions/otelcol/Dockerfile
 #
-FROM otel/opentelemetry-collector-contrib:0.84.0
+FROM otel/opentelemetry-collector-contrib:0.102.0
 
 LABEL org.opencontainers.image.authors="tech@opensafely.org" \
       org.opencontainers.image.url="opensafely.org" \

--- a/services/otel-gateway/justfile
+++ b/services/otel-gateway/justfile
@@ -4,6 +4,11 @@ export IMAGE_NAME := "otel-gateway"
 export DOCKER_BUILDKIT := "1"
 
 
+# list available commands
+default:
+    @"{{ just_executable() }}" --list
+
+
 _env:
     test -e .env || cp dotenv-sample .env
 


### PR DESCRIPTION
Tests pass without changes, v103+ tests fail for as yet uninvestigated reasons