### PR TITLE
Use uv instead of venv in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-ENV = env
+ENV = .venv
 
 $(ENV)/done: requirements.txt
-	virtualenv $(ENV)
-	$(ENV)/bin/pip install -r requirements.txt
+	uv virtualenv $(ENV)
+	uv pip install -r requirements.txt
 	touch $@
 
 


### PR DESCRIPTION
In a post uv world, we can't guarantee virtualenv in installed
