### PR TITLE
Remove excludes-newer in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,5 @@ extend-ignore = [
 [tool.ruff.lint.isort]
 lines-after-imports = 2
 
-# Note: any `exclude-newer-package` timestamps should be removed if > 7 days old
-# See https://github.com/opensafely-core/repo-template/blob/main/DEVELOPERS.md for details
 [tool.uv]
 required-version = ">=0.9"
-exclude-newer = "2026-02-04T00:00:00Z"
-exclude-newer-package = {}


### PR DESCRIPTION
We're not using the update-dependencies action in this repo, so we don't want any excludes-newer timestamps because they won't get regularly updated, and they prevent dependabot doing its thing (they were included accidentally when the repo was updated to use uv).