### PR TITLE
Update the TPP reboot checklist.

### DIFF
--- a/.github/ISSUE_TEMPLATE/tpp-reboot.md
+++ b/.github/ISSUE_TEMPLATE/tpp-reboot.md
@@ -3,19 +3,22 @@ name: TPP reboot
 about: Handling
 title: "[TPP reboot]"
 labels: ''
-assignees: pipeline-team
 
 ---
 
-Checklist for TPP reboot, to be created when TPP inform us of a maintenance window:
+Checklist for TPP reboot
+
 
 
 
 Preparation:
 
- - [ ] bring window start forward 10min, and extend window close by 30min, as TPP can be a bit optimistic about how long they need
- - [ ] schedule [maintenance window](https://support.freshstatus.io/en/support/solutions/articles/50000001851-how-to-create-a-planned-maintenance-incident-) in [freshstatus](https://bennettoxford.freshstatus.io/admin/incidents/public)
- - [ ] communicate advance notice of window to users on #opensafely and #opensafely-users Slack channels
+ - [ ] If TPP have inform us of a maintenance window, bring window start
+   forward 10min, and extend window close by 30min, as TPP can be a bit
+   optimistic about how long they need. If we are rebooting for other reasons,
+   decide on window.
+ - [ ] communicate advance notice of window to users on #opensafely and
+   #opensafely-users Slack channels
  - [ ] set Slack reminder for window start
 
 When window starts:
@@ -24,20 +27,18 @@ When window starts:
 
 See the [preparing for reboot](https://github.com/opensafely-core/backend-server/blob/main/playbook.md#preparing-for-reboot) section of the playbook for how to do this.
 
-These commands can also be scheduled in advance if the maintenance window is out of hours, see the [planned maintenance](https://github.com/opensafely-core/backend-server/blob/main/playbook.md#planned-maintenance) section for more details.
+Perform reboot
+ - [ ] if we are doing the reboot, then run `sudo reboot`. If TPP are stoping the VM, let them do it.
 
-When window closes:
+When window closes or the reboot has finished:
  - [ ] Check the VM is up and you can SSH in
-   - If not chase TPP via email for an update.
+   - If TPP initatied, chase TPP via email for an update.
    - It is likely they have not finished maintenance yet, if so you may need to extend window and communicate to users.
+   - If we initiated, we have limited options to debug failure, so we'll need to contact TPP to help diagnose.
 
 When the VM is back up:
  - [ ] Is docker up? run `docker ps` on the VM
  - [ ] Is job-runner up? [check status](https://jobs.opensafely.org/status/), or `sudo systemctl status jobrunner`
-
-If Level 4 was rebooted:
- - [ ] [manually start release hatch on the level 4 VM](https://bennettinstitute-team-manual.pages.dev/tech-group/playbooks/opensafely-tpp-level-4/#release-hatch)
-   - Note: once we've got the releases UI this will not be necessary
-
+ - [ ] If there were jobs that got stopped as part of shutdown, check they are running again
 Finally
- - [ ] close window on freshstatus if still active.
+ - [ ] notifiy users that maintenance is completed.

--- a/.github/ISSUE_TEMPLATE/tpp-reboot.md
+++ b/.github/ISSUE_TEMPLATE/tpp-reboot.md
@@ -13,7 +13,7 @@ Checklist for TPP reboot
 
 Preparation:
 
- - [ ] If TPP have inform us of a maintenance window, bring window start
+ - [ ] If TPP have informed us of a maintenance window, bring window start
    forward 10min, and extend window close by 30min, as TPP can be a bit
    optimistic about how long they need. If we are rebooting for other reasons,
    decide on reasonable window.
@@ -27,7 +27,7 @@ When window starts:
    This should kill all running tasks and pause the TPP backend to stop any new jobs.
 
 If TPP has scheduled this window out of hours, these commands can also be
-crudly scheduled using sleep. e.g. to sleep 4 hours then run things:
+crudely scheduled using sleep. e.g. to sleep 4 hours then run things:
 
 ```
 dokku4$ sleep $((4*3600)); dokku run rap-controller python manage.py prepare_for_reboot --backend tpp --skip-confirm
@@ -41,8 +41,8 @@ Perform reboot
 
 When window closes or the reboot has finished:
  - [ ] Check the VM is up and you can SSH in
-   - If TPP initatied, chase TPP via email for an update.
-   - If they have not finished maintenance yet, so you may need to extend window and communicate to users.
+   - If TPP initiated, chase TPP via email for an update.
+   - If they have not finished maintenance yet, you may need to extend window and communicate to users.
    - If we initiated, we have limited options to debug reboot failure, so we'll need to contact TPP to help diagnose.
 
 When the VM is back up:

--- a/.github/ISSUE_TEMPLATE/tpp-reboot.md
+++ b/.github/ISSUE_TEMPLATE/tpp-reboot.md
@@ -16,29 +16,39 @@ Preparation:
  - [ ] If TPP have inform us of a maintenance window, bring window start
    forward 10min, and extend window close by 30min, as TPP can be a bit
    optimistic about how long they need. If we are rebooting for other reasons,
-   decide on window.
+   decide on reasonable window.
  - [ ] communicate advance notice of window to users on #opensafely and
    #opensafely-users Slack channels
  - [ ] set Slack reminder for window start
 
 When window starts:
- - [ ] stop job runner
- - [ ] gracefully kill jobs
+ - [ ] follow the controller playbook to [prepare the TPP backend for
+   a reboot](https://github.com/opensafely-core/job-runner/blob/main/DEVELOPERS.md#prepare-for-reboot).
+   This should kill all running tasks and pause the TPP backend to stop any new jobs.
 
-See the [preparing for reboot](https://github.com/opensafely-core/backend-server/blob/main/playbook.md#preparing-for-reboot) section of the playbook for how to do this.
+If TPP has scheduled this window out of hours, these commands can also be
+crudly scheduled using sleep. e.g. to sleep 4 hours then run things:
+
+```
+dokku4$ sleep $((4*3600)); dokku run rap-controller python manage.py prepare_for_reboot --backend tpp --skip-confirm
+```
+
+Note: check playbook for up to date commands to run.
+
 
 Perform reboot
- - [ ] if we are doing the reboot, then run `sudo reboot`. If TPP are stoping the VM, let them do it.
+ - [ ] if we are doing the reboot, then run `sudo reboot` as your user. If TPP are stoping the VM, let them do it.
 
 When window closes or the reboot has finished:
  - [ ] Check the VM is up and you can SSH in
    - If TPP initatied, chase TPP via email for an update.
-   - It is likely they have not finished maintenance yet, if so you may need to extend window and communicate to users.
-   - If we initiated, we have limited options to debug failure, so we'll need to contact TPP to help diagnose.
+   - If they have not finished maintenance yet, so you may need to extend window and communicate to users.
+   - If we initiated, we have limited options to debug reboot failure, so we'll need to contact TPP to help diagnose.
 
 When the VM is back up:
- - [ ] Is docker up? run `docker ps` on the VM
- - [ ] Is job-runner up? [check status](https://jobs.opensafely.org/status/), or `sudo systemctl status jobrunner`
+ - [ ] Is the agent up? [check status](https://jobs.opensafely.org/status/)
+ - [ ] [Unpause the TPP backend on the controller](https://github.com/opensafely-core/job-runner/blob/main/DEVELOPERS.md#pause-a-backend)
  - [ ] If there were jobs that got stopped as part of shutdown, check they are running again
+
 Finally
- - [ ] notifiy users that maintenance is completed.
+ - [ ] notify users that maintenance is completed.


### PR DESCRIPTION
Haven't had to use it for a long time, as TPP haven't requested a reboot
for a while.

Removed some obsolete instructions, and also updated to account for
a reboot we initiate rather than TPP.
